### PR TITLE
Release v0.0.1 – initial public Maven Central publication

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,6 +30,11 @@ jobs:
 
     - name: Set up CMake
       uses: lukka/get-cmake@latest
+
+    - name: Create native directories
+      run: |
+        mkdir -p src/main/resources/native/linux-amd64
+
       
     - name: Configure and build
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,6 +31,10 @@ jobs:
     - name: Set up CMake
       uses: lukka/get-cmake@latest
       
+    - name: Create native directories
+      run: |
+        mkdir -p src/main/resources/native/macos-amd64
+       
     - name: Configure and build
       run: |
         mkdir -p build-mac

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,6 +32,10 @@ jobs:
     - name: Set up CMake
       uses: lukka/get-cmake@latest
       
+    - name: Create native directories
+      run: |
+        mkdir -p src/main/resources/native/windows-amd64
+
     - name: Configure CMake
       run: cmake -Bbuild -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release
       

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,22 +6,31 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Set Java resources native directory paths
+set(JAVA_RESOURCES_DIR "${CMAKE_SOURCE_DIR}/src/main/resources/native")
+
 # Set platform-specific output directories
 if(WIN32)
-    # Windows: put DLL in build/bin/Release
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin/Debug")
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/Release")
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/bin/Debug")
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/bin/Release")
+    # Windows: put DLL in Java resources directory for windows-amd64
+    set(PLATFORM_NATIVE_DIR "${JAVA_RESOURCES_DIR}/windows-amd64")
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PLATFORM_NATIVE_DIR}")
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${PLATFORM_NATIVE_DIR}")
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${PLATFORM_NATIVE_DIR}")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PLATFORM_NATIVE_DIR}")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG "${PLATFORM_NATIVE_DIR}")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE "${PLATFORM_NATIVE_DIR}")
 elseif(APPLE)
-    # Mac: put dylib in build-mac/bin
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+    # Mac: put dylib in Java resources directory for macos-amd64
+    set(PLATFORM_NATIVE_DIR "${JAVA_RESOURCES_DIR}/macos-amd64")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PLATFORM_NATIVE_DIR}")
 else()
-    # Linux: put .so in build-linux/lib
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+    # Linux: put .so in Java resources directory for linux-amd64
+    set(PLATFORM_NATIVE_DIR "${JAVA_RESOURCES_DIR}/linux-amd64")
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PLATFORM_NATIVE_DIR}")
 endif()
+
+# Create necessary directories
+file(MAKE_DIRECTORY ${PLATFORM_NATIVE_DIR})
 
 # Add blaze as a submodule
 add_subdirectory("${PROJECT_SOURCE_DIR}/deps/blaze")
@@ -29,8 +38,6 @@ add_subdirectory("${PROJECT_SOURCE_DIR}/deps/blaze")
 # Create the shared library
 add_library(blaze4j SHARED
     src/main/cpp/blaze_wrapper.cpp)
-
-# No need to redefine BLAZE_EXPORT here; the macro is set in the source file with proper platform guards.
 
 # Disable strcpy deprecation warning for MSVC
 if(MSVC)

--- a/pom.xml
+++ b/pom.xml
@@ -2,125 +2,161 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.madhavdhatrak</groupId>
-    <artifactId>blaze4j</artifactId>
-    <version>1.0-SNAPSHOT</version>
+  <groupId>io.github.madhavdhatrak</groupId>
+  <artifactId>blaze4j</artifactId>
+  <version>0.0.1</version>
 
-    <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+  <name>Blaze4j</name>
+  <description>A Java wrapper for the Sourcemeta Blaze JSON Schema validator using FFM</description>
+  <url>https://github.com/madhavdhatrak/blaze4j</url>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>madhavdhatrak</id>
+      <name>Madhav Dhatrak</name>
+      <email>madhavdhatrak02@gmail.com</email>
+      <organizationUrl>https://github.com/MadhavDhatrak</organizationUrl>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/MadhavDhatrak/Blaze4J.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/MadhavDhatrak/Blaze4J.git</developerConnection>
+    <url>https://github.com/MadhavDhatrak/Blaze4J</url>
+    <tag>HEAD</tag>
+  </scm>
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
-    <dependencies>
-        <!-- Panama API for FFM -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.16.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.16.1</version>
-        </dependency>
-    </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.9.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.16.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.16.1</version>
+    </dependency>
+  </dependencies>
 
-    <build>
-        <plugins>
+  <build>
+    <plugins>
+     
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
+        </configuration>
+      </plugin>
+
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>--enable-preview</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <doclint>none</doclint>
+          <additionalJOptions>
+            <additionalJOption>--enable-preview</additionalJOption>
+          </additionalJOptions>
+        </configuration>
+      </plugin>
+            <!-- Sign artifacts so Central sees .asc files -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
-                    <compilerArgs>
-                        <arg>--enable-preview</arg>
-                    </compilerArgs>
+                    <keyname>D0B5C504FC63D11F</keyname>
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
                 </configuration>
             </plugin>
             
-            <!-- Copy native library to target directory -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.3.1</version>
-                <executions>
-                    <execution>
-                        <id>copy-native-lib-windows</id>
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${project.basedir}/build/bin/Release</directory>
-                                    <includes>
-                                        <include>*.dll</include>
-                                        <include>*.pdb</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>copy-native-lib-linux</id>
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${project.basedir}/build-linux/lib</directory>
-                                    <includes>
-                                        <include>*.so</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>copy-native-lib-mac</id>
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${project.basedir}/build-mac/bin</directory>
-                                    <includes>
-                                        <include>*.dylib</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            
-            <!-- Configure surefire to use the native library -->
+            <!-- Unit tests with preview features enabled -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
-                    <argLine>--enable-preview --enable-native-access=ALL-UNNAMED -Djava.library.path=${project.build.directory}/classes${path.separator}${project.basedir}/build/bin/Release${path.separator}${project.basedir}/build-linux/lib${path.separator}${project.basedir}/build-mac/bin</argLine>
+                    <argLine>--enable-preview --enable-native-access=ALL-UNNAMED</argLine>
                     <useSystemClassLoader>true</useSystemClassLoader>
                 </configuration>
             </plugin>
-        </plugins>
-    </build>
+    </plugins>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <includes>
+          <include>**/*</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
 </project>

--- a/src/main/java/com/github/madhavdhatrak/blaze4j/BlazeWrapper.java
+++ b/src/main/java/com/github/madhavdhatrak/blaze4j/BlazeWrapper.java
@@ -29,32 +29,18 @@ class BlazeWrapper {
 
     static {
         try {
-            // Try to load the library using its base name first
+            // Try using standard System.loadLibrary first
             System.loadLibrary("blaze4j");
         } catch (UnsatisfiedLinkError e) {
-            // If that fails, try platform-specific paths
-            String osName = System.getProperty("os.name").toLowerCase();
-            String userDir = System.getProperty("user.dir").replace("\\", "/");
-            String libPath;
-            
-            if (osName.contains("win")) {
-                // Windows path
-                libPath = userDir + "/build/bin/Release/blaze4j.dll";
-            } else if (osName.contains("mac")) {
-                // Mac path
-                libPath = userDir + "/build-mac/bin/blaze4j.dylib";
-            } else {
-                // Linux/WSL path
-                libPath = userDir + "/build-linux/lib/libblaze4j.so";
-                
-                // Check if file exists, if not try alternative location
-                if (!new File(libPath).exists()) {
-                    libPath = userDir + "/build/libblaze4j.so";
-                }
+            // If that fails, try using the NativeLoader to extract from JAR
+            try {
+                NativeLoader.loadLibrary("blaze4j");
+                System.out.println("Loaded native library from JAR");
+            } catch (Exception ex) {
+                System.err.println("FATAL: Failed to load native library: " + ex.getMessage());
+                ex.printStackTrace();
+                throw new RuntimeException("Failed to load native library: " + ex.getMessage(), ex);
             }
-            
-            System.out.println("Attempting to load library from: " + libPath);
-            System.load(libPath);
         }
 
         symbolLookup = SymbolLookup.loaderLookup();

--- a/src/main/java/com/github/madhavdhatrak/blaze4j/NativeLoader.java
+++ b/src/main/java/com/github/madhavdhatrak/blaze4j/NativeLoader.java
@@ -1,0 +1,46 @@
+package com.github.madhavdhatrak.blaze4j;
+
+import java.io.*;
+import java.nio.file.*;
+
+public class NativeLoader {
+    public static void loadLibrary(String libName) throws IOException {
+        String os = System.getProperty("os.name").toLowerCase();
+        String arch = System.getProperty("os.arch").toLowerCase();
+        String platform;
+
+        if (os.contains("win")) {
+            platform = "windows-amd64";
+            libName += ".dll";
+        } else if (os.contains("mac")) {
+            platform = "macos-amd64";
+            if (libName.startsWith("lib")) {
+                libName += ".dylib";
+            } else {
+                libName = "lib" + libName + ".dylib";
+            }
+        } else if (os.contains("wsl") || os.contains("linux")) {
+            platform = "linux-amd64";
+            if (libName.startsWith("lib")) {
+                libName += ".so";
+            } else {
+                libName = "lib" + libName + ".so";
+            }
+        } else {
+            throw new UnsupportedOperationException("Unsupported OS: " + os);
+        }
+
+        String resourcePath = "native/" + platform + "/" + libName;
+         
+        try (InputStream in = NativeLoader.class.getClassLoader().getResourceAsStream(resourcePath)) {
+            if (in == null) {
+                throw new FileNotFoundException("Native library not found: " + resourcePath);
+            }
+
+            File tempFile = File.createTempFile("native-", libName);
+            tempFile.deleteOnExit();
+            Files.copy(in, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            System.load(tempFile.getAbsolutePath());
+        }
+    }
+} 


### PR DESCRIPTION
Release v0.0.1 – Initial Blaze4J on Maven Central

This PR publishes the inaugural release of blaze4j to Maven Central:

### Highlights
- blaze4j v0.0.1: A Java wrapper around the native Blaze JSON Schema validation engine.

- Enables JSON Schema validation from JVM apps using Blaze’s fast, native implementation.

- Includes artifacts: blaze4j-core, Javadoc, sources – now available via Maven coordinates:
```io.github.madhavdhatrak:blaze4j:0.0.1```


What's Included
- Built via Maven with necessary metadata (POM, licensing, etc.)

- GPG-signed artifacts uploaded to Sonatype OSSRH

- Verified deployment on Maven Central: [artifact link](https://central.sonatype.com/artifact/io.github.madhavdhatrak/blaze4j/0.0.1)