### PR TITLE
docs: add installation guide and update README for Blaze4j v0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Blaze4J enables Java developers to validate JSON documents against JSON Schema s
 
 - [Overview](#overview)
 - [Features](#features)
-- [Project Structure](#project-structure)
 - [Installation](./installation.md) 
 - [Usage](#usage) 
 - [Supported Drafts](#supported-drafts) 
@@ -43,32 +42,7 @@ Blaze4J bridges Java and native C++ for **fast, standards-compliant JSON Schema 
 - **Easy integration**: Simple API for compiling schemas and validating instances.
 - **Cross-platform**: Works on Windows, Linux, and macOS.
 
---- 
-## Project Structure
 
-
-```
-├── src/
-│   ├── main/
-│   │   ├── java/
-│   │   │   └── com/sourcemeta/blaze/
-│   │   │       ├── CompiledSchema.java
-│   │   │       ├── BlazeWrapper.java
-│   │   │       ├── BlazeValidator.java
-│   │   │       └── Blaze.java
-│   │   └── cpp/
-│   │       └── blaze_wrapper.cpp
-│   └── test/
-│       └── java/
-│           └── com/sourcemeta/blaze/wrapper/
-│               └── BlazeWrapperTest.java
-├── deps/
-│   └── blaze/          # Git submodule for Blaze library
-├── build/              # Build output directory (contains platform-specific shared libraries)
-├── pom.xml            # Maven build configuration
-└── CMakeLists.txt     # CMake configuration
-
-```
 ---
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Blaze4J enables Java developers to validate JSON documents against JSON Schema s
 - [Usage](#usage) 
 - [Supported Drafts](#supported-drafts) 
 - [Supported Resolvers](#supported-resolvers) 
-- [Dependencies](#dependencies)
 - [API Documentation](#api-documentation)
   - [Compiler API](./docs/compiler.md)
   - [Validator API](./docs/validator.md)
@@ -158,11 +157,12 @@ import com.github.madhavdhatrak.blaze4j.BlazeValidator;
 
 public class Test {
     public static void main(String[] args) {
-
-        String schemaJson = "{"
-            + "\"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
-            + "\"type\": \"string\""
-            + "}";
+        String schemaJson = """
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "string"
+            }
+            """;
 
         try (CompiledSchema schema = Blaze.compile(schemaJson)) {
             final BlazeValidator validator = new BlazeValidator();
@@ -170,6 +170,8 @@ public class Test {
             // Test valid string input
             boolean validStringResult = validator.validate(schema, "\"hello\"");
             System.out.println("Validation result for \"hello\": " + validStringResult);
+            
+            // Test invalid number input
             boolean invalidNumberResult = validator.validate(schema, "42");
             System.out.println("Validation result for 42: " + invalidNumberResult);
         }
@@ -187,11 +189,12 @@ import com.github.madhavdhatrak.blaze4j.ValidationError;
 
 public class TestBlaze4j {
     public static void main(String[] args) {
-        System.out.println("\nTesting enum validation:");
-        String enumSchemaJson = "{"
-            + "\"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
-            + "\"enum\": [\"red\", \"green\", \"blue\"]"
-            + "}";
+        String enumSchemaJson = """
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "enum": ["red", "green", "blue"]
+            }
+            """;
 
         String invalidEnumInstance = "\"yellow\"";
 
@@ -204,13 +207,9 @@ public class TestBlaze4j {
                 System.out.println("Validation errors:");
                 result.getErrors().forEach(System.out::println);
             }
-        } catch (Exception e) {
-            System.err.println("Error: " + e.getMessage());
-            e.printStackTrace();
         }
     }
 }
-
 ```
 
 ---
@@ -235,15 +234,6 @@ public class TestBlaze4j {
 
 ---
 
-
-## Dependencies
-
-- Java Development Kit (JDK) 11 or higher
-- CMake 3.10 or higher
-- C++ compiler with C++11 support
-- Blaze library (included as a Git submodule)
-
-
 ## API Documentation
 
 - [Compiler API](./docs/Compiler.md)- How to compile schemas, manage memory, and use different dialects.
@@ -263,7 +253,8 @@ public class TestBlaze4j {
 
 Feel free to open an issue for bugs or feature requests, or submit a pull request to improve the project. Whether it's fixing a typo, improving the docs, or adding new features—every contribution counts!
 
-For local installation, see [installation.md](installation.md)
+For local installation and development, see [CONTRIBUTING.md](./docs/CONTRIBUTING.md). The project uses Git submodules, so when cloning the repository, use:
+
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -4,29 +4,22 @@
 
 Blaze4J enables Java developers to validate JSON documents against JSON Schema specifications (supporting multiple draft versions) with minimal overhead and maximum efficiency.
 
-
 ---
 <p align="center">
   <img src="https://github.com/user-attachments/assets/5b1f7e38-4614-446e-985c-6ad2cc135ff3" width="516" height="346" alt="Image 2" />
 </p>
-
 ---
 
 ## Table of Contents
 
 - [Overview](#overview)
 - [Features](#features)
+- [Project Structure](#project-structure)
+- [Installation](./installation.md) 
+- [Usage](#usage) 
 - [Supported Drafts](#supported-drafts) 
 - [Supported Resolvers](#supported-resolvers) 
-- [Project Structure](#project-structure)
 - [Dependencies](#dependencies)
-- [Build Instructions](#build-instructions)
-  - [Initialize Blaze Submodule](#1-initialize-blaze-submodule)
-  - [Build for Windows](#2-build-for-windows)
-  - [Build for Linux](#3-build-for-linux)
-  - [Build for macOS](#4-build-for-macos)
-- [Testing](#testing)
-- [Usage](#usage)
 - [API Documentation](#api-documentation)
   - [Compiler API](./docs/compiler.md)
   - [Validator API](./docs/validator.md)
@@ -51,31 +44,10 @@ Blaze4J bridges Java and native C++ for **fast, standards-compliant JSON Schema 
 - **Easy integration**: Simple API for compiling schemas and validating instances.
 - **Cross-platform**: Works on Windows, Linux, and macOS.
 
----
-
-## Supported Drafts 
-
-| Draft Version | Status        | Specification                                                                 |
-|---------------|--------------|-------------------------------------------------------------------------------|
-| Draft 2020-12 | ✅ Supported | [Spec](https://json-schema.org/draft/2020-12/release-notes.html)              |
-| Draft 2019-09 | ✅ Supported | [Spec](https://json-schema.org/draft/2019-09/release-notes.html)              |
-| Draft 7       | ✅ Supported | [Spec](https://json-schema.org/draft-07/release-notes.html)                   |
-| Draft 6       | ✅ Supported | [Spec](https://json-schema.org/draft-06/release-notes.html)                   |
-| Draft 4       | ✅ Supported | [Spec](https://json-schema.org/draft-04/release-notes.html)                   |
-
-
----
-<a name="supported-resolvers"></a>
-## Supported `$ref` Resolvers:
-
-| Resolver Type | Status        | Description                                   |
-|---------------|---------------|-----------------------------------------------|
-| `http`        | ✅ Supported  | Resolves external schemas via HTTP(S) URLs    |
-| `classpath`   | ✅ Supported  | Resolves schemas from the Java classpath      |
-
----
-
+--- 
 ## Project Structure
+
+
 ```
 ├── src/
 │   ├── main/
@@ -98,8 +70,171 @@ Blaze4J bridges Java and native C++ for **fast, standards-compliant JSON Schema 
 └── CMakeLists.txt     # CMake configuration
 
 ```
+---
+
+## Installation
+
+**Maven**
+- Add the following dependency to your `pom.xml`:
+```java
+<dependency>
+    <groupId>io.github.madhavdhatrak</groupId>
+    <artifactId>blaze4j</artifactId>
+    <version>0.0.1</version>
+</dependency>
+
+```
+
+**Gradle**
+- Add this to your `build.gradle`:
+```java
+implementation group: 'io.github.madhavdhatrak', name: 'blaze4j', version: '0.0.1'
+```
+
+ **Make Sure to have pom.xml Like this**
+```java
+<properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+</properties>
+
+<dependencies>
+    <dependency>
+        <groupId>io.github.madhavdhatrak</groupId>
+        <artifactId>blaze4j</artifactId>
+        <version>0.0.1</version>
+    </dependency>
+</dependencies>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.11.0</version>
+            <configuration>
+                <compilerArgs>
+                    <arg>--enable-preview</arg>
+                </compilerArgs>
+            </configuration>
+        </plugin>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.1.0</version>
+            <configuration>
+                <executable>java</executable>
+                <arguments>
+                    <argument>--enable-preview</argument>
+                    <argument>--enable-native-access=ALL-UNNAMED</argument>
+                    <argument>-classpath</argument>
+                    <classpath/>
+                    <argument>${exec.mainClass}</argument>
+                </arguments>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+```
+
+**Testing**
+- **Run your test class using**:
+```java
+mvn clean compile exec:exec -Dexec.mainClass=com.example.Test
+```
+_**Replace com.example.Test with the path to your test class**_.
+
+
+## Usage 
+- **Simple Boolean Result**
+
+```java
+package com.example;
+
+import com.github.madhavdhatrak.blaze4j.Blaze;
+import com.github.madhavdhatrak.blaze4j.CompiledSchema;
+import com.github.madhavdhatrak.blaze4j.BlazeValidator;
+
+public class Test {
+    public static void main(String[] args) {
+
+        String schemaJson = "{"
+            + "\"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
+            + "\"type\": \"string\""
+            + "}";
+
+        try (CompiledSchema schema = Blaze.compile(schemaJson)) {
+            final BlazeValidator validator = new BlazeValidator();
+            
+            // Test valid string input
+            boolean validStringResult = validator.validate(schema, "\"hello\"");
+            System.out.println("Validation result for \"hello\": " + validStringResult);
+            boolean invalidNumberResult = validator.validate(schema, "42");
+            System.out.println("Validation result for 42: " + invalidNumberResult);
+        }
+    }
+}
+```
+- **Detailed Error Reporting**
+```java
+package com.example;
+
+import com.github.madhavdhatrak.blaze4j.Blaze;
+import com.github.madhavdhatrak.blaze4j.CompiledSchema;
+import com.github.madhavdhatrak.blaze4j.ValidationResult;
+import com.github.madhavdhatrak.blaze4j.ValidationError;
+
+public class TestBlaze4j {
+    public static void main(String[] args) {
+        System.out.println("\nTesting enum validation:");
+        String enumSchemaJson = "{"
+            + "\"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
+            + "\"enum\": [\"red\", \"green\", \"blue\"]"
+            + "}";
+
+        String invalidEnumInstance = "\"yellow\"";
+
+        try (CompiledSchema compiledSchema = Blaze.compile(enumSchemaJson)) {
+            ValidationResult result = Blaze.validateWithDetails(compiledSchema, invalidEnumInstance);
+
+            System.out.println("Is valid: " + result.isValid());
+
+            if (!result.isValid()) {
+                System.out.println("Validation errors:");
+                result.getErrors().forEach(System.out::println);
+            }
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}
+
+```
 
 ---
+## Supported Drafts 
+
+| Draft Version | Status        | Specification                                                                 |
+|---------------|--------------|-------------------------------------------------------------------------------|
+| Draft 2020-12 | ✅ Supported | [Spec](https://json-schema.org/draft/2020-12/release-notes.html)              |
+| Draft 2019-09 | ✅ Supported | [Spec](https://json-schema.org/draft/2019-09/release-notes.html)              |
+| Draft 7       | ✅ Supported | [Spec](https://json-schema.org/draft-07/release-notes.html)                   |
+| Draft 6       | ✅ Supported | [Spec](https://json-schema.org/draft-06/release-notes.html)                   |
+| Draft 4       | ✅ Supported | [Spec](https://json-schema.org/draft-04/release-notes.html)                   |
+
+---
+<a name="supported-resolvers"></a>
+## Supported `$ref` Resolvers:
+
+| Resolver Type | Status        | Description                                   |
+|---------------|---------------|-----------------------------------------------|
+| `http`        | ✅ Supported  | Resolves external schemas via HTTP(S) URLs    |
+| `classpath`   | ✅ Supported  | Resolves schemas from the Java classpath      |
+
+---
+
 
 ## Dependencies
 
@@ -108,91 +243,6 @@ Blaze4J bridges Java and native C++ for **fast, standards-compliant JSON Schema 
 - C++ compiler with C++11 support
 - Blaze library (included as a Git submodule)
 
----
-
-## Build Instructions
-
-### 1. Initialize Blaze Submodule
-```
-git submodule add https://github.com/sourcemeta/blaze.git deps/blaze
-```
-
-### 2. Build for Windows
-```java
-mkdir build
-cmake -Bbuild -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release
-cmake --build build --config Release
-```
-### 3. Build for Linux
-```java
-mkdir -p build-linux
-cd build-linux
-cmake .. -DCMAKE_BUILD_TYPE=Release
-make
-```
-### 4. Build for macOS
-```
-mkdir -p build-mac
-cd build-mac
-cmake .. -DCMAKE_BUILD_TYPE=Release
-cmake --build . --config Release
-```
-This will generate platform-specific shared libraries (`.dll` on Windows, `.so` on Linux, `.dylib` for macOS) in the build directory.
-
----
-
-## Testing
-
-First, add the JSON Schema Test Suite as a submodule:
-```
-git submodule add https://github.com/json-schema-org/JSON-Schema-Test-Suite.git src/test/resources/JSON-Schema-Test-Suite
-```
-
-**Run the test suite for each draft:**
-```bash
-mvn test -Dtest=Draft2020Runner 
-```
-```bash
-mvn test -Dtest=Draft2019Runner 
-```
-```bash
-mvn test -Dtest=Draft7Runner 
-```
-```bash
-mvn test -Dtest=Draft6Runner 
-```
-```bash
-mvn test -Dtest=Draft4Runner 
-```
----
-
-## Usage
-
-```java
-
-String schemaJson = "{"
-    + "\"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
-    + "\"type\": \"string\""
-    + "}";
-
-String instance = "\"hello\"";
-
-try (CompiledSchema compiledSchema = Blaze.compile(schemaJson)) {
-    ValidationResult result = Blaze.validateWithDetails(compiledSchema, instance);
-
-    System.out.println("Is valid: " + result.isValid());
-
-    if (!result.isValid()) {
-        result.getErrors().forEach(error -> {
-            System.out.println("- message      : " + error.getMessage());
-            System.out.println("  instancePath : " + error.getInstancePath());
-            System.out.println("  schemaPath   : " + error.getSchemaPath());
-        });
-    }
-}
-
-```
----
 
 ## API Documentation
 
@@ -211,7 +261,9 @@ try (CompiledSchema compiledSchema = Blaze.compile(schemaJson)) {
 
 ## Contributing
 
-Feel free to open an issue for bugs or feature requests, or submit a pull request to improve the project. Whether it’s fixing a typo, improving docs, or adding new features—every contribution counts!
+Feel free to open an issue for bugs or feature requests, or submit a pull request to improve the project. Whether it's fixing a typo, improving the docs, or adding new features—every contribution counts!
+
+For local installation, see [installation.md](installation.md)
 
 ## Credits
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,13 +1,13 @@
-# Installation and Local Development
+# Contributing to Blaze4J
 
-This guide explains how to **build Blaze4J from source** and run the official JSON Schema Test Suite for all supported drafts.
+This guide explains how to contribute to Blaze4J, including how to set up your development environment, build the project from source, and run tests.
 
 ---
 
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
-- [1. Initialize Blaze Submodule](#1-initialize-blaze-submodule)
+- [1. Clone and Initialize Submodules](#1-clone-and-initialize-submodules)
 - [2. Build Native Libraries](#2-build-native-libraries)
   - [Windows](#windows)
   - [Linux](#linux)
@@ -15,6 +15,7 @@ This guide explains how to **build Blaze4J from source** and run the official JS
 - [3. JSON Schema Test Suite (Drafts)](#3-json-schema-test-suite-drafts)
   - [A. Add Test Suite Submodule](#a-add-test-suite-submodule)
   - [B. Run Draft Test Runners](#b-run-draft-test-runners)
+- [Pull Request Guidelines](#pull-request-guidelines)
 - [Notes](#notes)
 
 ---
@@ -23,24 +24,30 @@ This guide explains how to **build Blaze4J from source** and run the official JS
 
 Make sure you have the following tools installed:
 
-- **Java Development Kit (JDK) 11** or higher
+- **Java Development Kit (JDK) 21** or higher
 - **CMake 3.10** or higher
 - **C++ compiler** with C++11 support
 - **Git** (for submodules)
 
 ---
 
-## 1. Initialize Blaze Submodule
+## 1. Clone and Initialize Submodules
 
-Clone the repository
-```
+Blaze4J uses Git submodules to include the Blaze library. You can clone the repository and all its submodules in a single command:
+
+```bash
 git clone https://github.com/MadhavDhatrak/Blaze4J.git
+cd Blaze4J
 ```
 
- then run:
+Add blaze as a Submodule:
+Run this command:
+
 ```bash
 git submodule add https://github.com/sourcemeta/blaze.git deps/blaze
 ```
+
+This will ensure you have the exact version of the Blaze library that Blaze4J is designed to work with.
 
 ## 2. Build Native Libraries
 
@@ -72,9 +79,16 @@ cmake --build . --config Release
 
 ### A. Add Test Suite Submodule
 
-Add the official JSON Schema Test Suite:
-```
+If the JSON Schema Test Suite submodule is not already initialized (it should be if you used `--recurse-submodules` when cloning), you can add it with:
+
+```bash
 git submodule add https://github.com/json-schema-org/JSON-Schema-Test-Suite.git src/test/resources/JSON-Schema-Test-Suite
+```
+
+Or update it if it already exists:
+
+```bash
+git submodule update --init --recursive src/test/resources/JSON-Schema-Test-Suite
 ```
 
 ### B. Run Draft Test Runners
@@ -87,6 +101,12 @@ mvn test -Dtest=Draft7Runner
 mvn test -Dtest=Draft6Runner
 mvn test -Dtest=Draft4Runner
 ```
+
+## Pull Request Guidelines
+
+- Ensure your changes are well-documented and follow the existing code style.
+- Run the test suite to ensure your changes do not break existing functionality.
+- Update the documentation if your changes affect the user-facing API.
 
 ## Notes
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -36,18 +36,9 @@ Make sure you have the following tools installed:
 Blaze4J uses Git submodules to include the Blaze library. You can clone the repository and all its submodules in a single command:
 
 ```bash
-git clone https://github.com/MadhavDhatrak/Blaze4J.git
+git clone --recurse-submodules https://github.com/MadhavDhatrak/Blaze4J.git
 cd Blaze4J
 ```
-
-Add blaze as a Submodule:
-Run this command:
-
-```bash
-git submodule add https://github.com/sourcemeta/blaze.git deps/blaze
-```
-
-This will ensure you have the exact version of the Blaze library that Blaze4J is designed to work with.
 
 ## 2. Build Native Libraries
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,94 @@
+# Installation and Local Development
+
+This guide explains how to **build Blaze4J from source** and run the official JSON Schema Test Suite for all supported drafts.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [1. Initialize Blaze Submodule](#1-initialize-blaze-submodule)
+- [2. Build Native Libraries](#2-build-native-libraries)
+  - [Windows](#windows)
+  - [Linux](#linux)
+  - [macOS](#macos)
+- [3. JSON Schema Test Suite (Drafts)](#3-json-schema-test-suite-drafts)
+  - [A. Add Test Suite Submodule](#a-add-test-suite-submodule)
+  - [B. Run Draft Test Runners](#b-run-draft-test-runners)
+- [Notes](#notes)
+
+---
+
+## Prerequisites
+
+Make sure you have the following tools installed:
+
+- **Java Development Kit (JDK) 11** or higher
+- **CMake 3.10** or higher
+- **C++ compiler** with C++11 support
+- **Git** (for submodules)
+
+---
+
+## 1. Initialize Blaze Submodule
+
+Clone the repository
+```
+git clone https://github.com/MadhavDhatrak/Blaze4J.git
+```
+
+ then run:
+```bash
+git submodule add https://github.com/sourcemeta/blaze.git deps/blaze
+```
+
+## 2. Build Native Libraries
+
+> The resulting shared libraries (\*.dll / \*.so / \*.dylib) will be in your build directory.
+
+### Windows
+```java
+mkdir build
+cmake -Bbuild -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+```
+### Linux
+```java
+mkdir -p build-linux
+cd build-linux
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make
+```
+
+### macOS
+```java
+mkdir -p build-mac
+cd build-mac
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . --config Release
+```
+
+## 3. JSON Schema Test Suite (Drafts)
+
+### A. Add Test Suite Submodule
+
+Add the official JSON Schema Test Suite:
+```
+git submodule add https://github.com/json-schema-org/JSON-Schema-Test-Suite.git src/test/resources/JSON-Schema-Test-Suite
+```
+
+### B. Run Draft Test Runners
+
+Run your Maven test runner for each draft:
+```java
+mvn test -Dtest=Draft2020Runner
+mvn test -Dtest=Draft2019Runner
+mvn test -Dtest=Draft7Runner
+mvn test -Dtest=Draft6Runner
+mvn test -Dtest=Draft4Runner
+```
+
+## Notes
+
+- For full usage instructions and API documentation, see [README.md](./README.md).
+- For troubleshooting or contributions, open an issue or pull request on GitHub.


### PR DESCRIPTION
## 🔧 PR Title:
**docs: add installation guide and update README for Blaze4j v0.0.1**

---

## 📄 Description:
This PR includes the following documentation updates for **Blaze4j v0.0.1**:

-  Added `installation.md` with clear steps for local setup.
-  Updated `README.md` to:
  - Link to the new installation guide.
  - Added usage
  


