### PR TITLE
Fix : Draft2020Test typo changing boolean.json to boolean_schema.json.

### DIFF
--- a/src/test/java/com/github/madhavdhatrak/blaze4j/Draft2020Runner.java
+++ b/src/test/java/com/github/madhavdhatrak/blaze4j/Draft2020Runner.java
@@ -64,7 +64,7 @@ public class Draft2020Runner {
     "allOf.json",
     "anchor.json",
     "anyOf.json",
-    "boolean.json",
+    "boolean_schema.json",
     "const.json",
     "contains.json",
     "content.json",


### PR DESCRIPTION
This PR  fixes the typo in the Draft2020Runner file, changing boolean.json to boolean_schema.json.

