### PR TITLE
Update Documentation to Use Multiline Strings and Correct API

### DIFF
--- a/docs/Compiler.md
+++ b/docs/Compiler.md
@@ -32,11 +32,10 @@ The BlazeWrapper Schema Compiler allows you to compile JSON Schema documents int
 
 **Compiles a JSON schema string using the default dialect specified within the schema (if present)**.
 ```java
-public static CompiledSchema compile(String schema)
-
+public CompiledSchema compile(String schema)
 ```
 - **Parameters:**
-  - `schema`: The JSON schema as a string.
+  - `schema`: The JSON schema as a string (supports multiline strings).
 - **Returns:** `CompiledSchema` — the compiled schema instance.
 - **Behavior:** Internally creates and manages an `Arena` for resource management. Uses the `$schema` property in the schema to determine the dialect.
 
@@ -46,10 +45,10 @@ public static CompiledSchema compile(String schema)
 
 **Compiles a JSON schema string, allowing you to specify a default dialect if the schema does not declare one**
 ```java
-public static CompiledSchema compile(String schema, String defaultDialect)
+public CompiledSchema compile(String schema, String defaultDialect)
 ```
 - **Parameters:**
-  - `schema`: The JSON schema as a string.
+  - `schema`: The JSON schema as a string (supports multiline strings).
   - `defaultDialect`: The default dialect URI to use if the schema does not specify one.
 - **Returns:** `CompiledSchema` — the compiled schema instance.
 - **Behavior:** Internally creates and manages an `Arena`. If the schema does not specify a `$schema` property, `defaultDialect` is used.
@@ -60,10 +59,10 @@ public static CompiledSchema compile(String schema, String defaultDialect)
 
 **Compiles a JSON schema string using the provided Arena for resource management.**
 ```java
-public static CompiledSchema compile(String schema, Arena arena)
+public CompiledSchema compile(String schema, Arena arena)
 ```
 - **Parameters:**
-  - `schema`: The JSON schema as a string.
+  - `schema`: The JSON schema as a string (supports multiline strings).
   - `arena`: The memory arena for resource management.
 - **Returns:** `CompiledSchema` — the compiled schema instance.
 - **Behavior:** Uses the provided `Arena` to manage the lifecycle of the compiled schema, allowing for explicit control over memory/resource management.
@@ -74,10 +73,10 @@ public static CompiledSchema compile(String schema, Arena arena)
 
 **Compiles a JSON schema string with an explicit default dialect, using the provided Arena for resource management.**
 ```java
-public static CompiledSchema compile(String schema, Arena arena, String defaultDialect)
+public CompiledSchema compile(String schema, Arena arena, String defaultDialect)
 ```
 - **Parameters:**
-  - `schema`: The JSON schema as a string.
+  - `schema`: The JSON schema as a string (supports multiline strings).
   - `arena`: The memory arena for resource management.
   - `defaultDialect`: The default dialect URI to use if the schema does not specify one.
 - **Returns:** `CompiledSchema` — the compiled schema instance.
@@ -88,56 +87,59 @@ public static CompiledSchema compile(String schema, Arena arena, String defaultD
 
 ### Example 1: Compiling with Schema-Declared Dialect
 ```java
-String schemaJson = "{"
-+ ""$schema": "https://json-schema.org/draft/2020-12/schema\","
-+ ""type": "string""
-+ "}";
+String schemaJson = """
+    {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string"
+    }
+    """;
 
-try (CompiledSchema schema = Blaze.compile(schemaJson)) {
-BlazeValidator validator = new BlazeValidator();
+SchemaCompiler compiler = new SchemaCompiler();
+try (CompiledSchema schema = compiler.compile(schemaJson)) {
+    BlazeValidator validator = new BlazeValidator();
 
-boolean validStringResult = validator.validate(schema, "\"hello\"");
-System.out.println("Validation result for \"hello\": " + validStringResult);
-assertTrue(validStringResult);
+    boolean validStringResult = validator.validate(schema, "\"hello\"");
+    System.out.println("Validation result for \"hello\": " + validStringResult);
 }
-
 ```
 ### Example 2: Compiling with Explicit Default Dialect
 ```java
-String schemaJson = "{"
-+ ""type": "string""
-+ "}";
+String schemaJson = """
+    {
+        "type": "string"
+    }
+    """;
 
 String defaultDialect = "https://json-schema.org/draft/2020-12/schema";
 
-try (CompiledSchema schema = Blaze.compile(schemaJson, defaultDialect)) {
-BlazeValidator validator = new BlazeValidator();
+SchemaCompiler compiler = new SchemaCompiler();
+try (CompiledSchema schema = compiler.compile(schemaJson, defaultDialect)) {
+    BlazeValidator validator = new BlazeValidator();
 
-boolean validStringResult = validator.validate(schema, "\"world\"");
-System.out.println("Validation result for \"world\": " + validStringResult);
-assertTrue(validStringResult);
+    boolean validStringResult = validator.validate(schema, "\"world\"");
+    System.out.println("Validation result for \"world\": " + validStringResult);
 }
-
 ```
 
 ### Example 3: Compiling with Arena (Resource Management Control)
 ```java
 import java.lang.foreign.Arena;
 
-String schemaJson = "{"
-+ ""$schema": "https://json-schema.org/draft/2020-12/schema\","
-+ ""type": "string""
-+ "}";
+String schemaJson = """
+    {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string"
+    }
+    """;
 
+SchemaCompiler compiler = new SchemaCompiler();
 try (Arena arena = Arena.ofConfined();
-CompiledSchema compiledSchema = Blaze.compile(schemaJson, arena)) {
-BlazeValidator validator = new BlazeValidator();
+     CompiledSchema compiledSchema = compiler.compile(schemaJson, arena)) {
+    BlazeValidator validator = new BlazeValidator();
 
-boolean validStringResult = validator.validate(compiledSchema, "\"hello\"");
-System.out.println("Validation result for \"hello\": " + validStringResult);
-assertTrue(validStringResult);
+    boolean validStringResult = validator.validate(compiledSchema, "\"hello\"");
+    System.out.println("Validation result for \"hello\": " + validStringResult);
 }
-
 ```
 
 
@@ -145,19 +147,21 @@ assertTrue(validStringResult);
 ```java
 import java.lang.foreign.Arena;
 
-String schemaJson = "{"
-+ ""type": "string""
-+ "}";
+String schemaJson = """
+    {
+        "type": "string"
+    }
+    """;
 
 String defaultDialect = "https://json-schema.org/draft/2020-12/schema";
 
+SchemaCompiler compiler = new SchemaCompiler();
 try (Arena arena = Arena.ofConfined();
-CompiledSchema compiledSchema = Blaze.compile(schemaJson, arena, defaultDialect)) {
-BlazeValidator validator = new BlazeValidator();
+     CompiledSchema compiledSchema = compiler.compile(schemaJson, arena, defaultDialect)) {
+    BlazeValidator validator = new BlazeValidator();
 
-boolean validStringResult = validator.validate(compiledSchema, "\"world\"");
-System.out.println("Validation result for \"world\": " + validStringResult);
-assertTrue(validStringResult);
+    boolean validStringResult = validator.validate(compiledSchema, "\"world\"");
+    System.out.println("Validation result for \"world\": " + validStringResult);
 }
 ```
 

--- a/docs/Compiler.md
+++ b/docs/Compiler.md
@@ -35,7 +35,7 @@ The BlazeWrapper Schema Compiler allows you to compile JSON Schema documents int
 public CompiledSchema compile(String schema)
 ```
 - **Parameters:**
-  - `schema`: The JSON schema as a string (supports multiline strings).
+  - `schema`: The JSON schema as a string 
 - **Returns:** `CompiledSchema` — the compiled schema instance.
 - **Behavior:** Internally creates and manages an `Arena` for resource management. Uses the `$schema` property in the schema to determine the dialect.
 
@@ -48,7 +48,7 @@ public CompiledSchema compile(String schema)
 public CompiledSchema compile(String schema, String defaultDialect)
 ```
 - **Parameters:**
-  - `schema`: The JSON schema as a string (supports multiline strings).
+  - `schema`: The JSON schema as a string 
   - `defaultDialect`: The default dialect URI to use if the schema does not specify one.
 - **Returns:** `CompiledSchema` — the compiled schema instance.
 - **Behavior:** Internally creates and manages an `Arena`. If the schema does not specify a `$schema` property, `defaultDialect` is used.
@@ -62,7 +62,7 @@ public CompiledSchema compile(String schema, String defaultDialect)
 public CompiledSchema compile(String schema, Arena arena)
 ```
 - **Parameters:**
-  - `schema`: The JSON schema as a string (supports multiline strings).
+  - `schema`: The JSON schema as a string 
   - `arena`: The memory arena for resource management.
 - **Returns:** `CompiledSchema` — the compiled schema instance.
 - **Behavior:** Uses the provided `Arena` to manage the lifecycle of the compiled schema, allowing for explicit control over memory/resource management.
@@ -76,7 +76,7 @@ public CompiledSchema compile(String schema, Arena arena)
 public CompiledSchema compile(String schema, Arena arena, String defaultDialect)
 ```
 - **Parameters:**
-  - `schema`: The JSON schema as a string (supports multiline strings).
+  - `schema`: The JSON schema as a string 
   - `arena`: The memory arena for resource management.
   - `defaultDialect`: The default dialect URI to use if the schema does not specify one.
 - **Returns:** `CompiledSchema` — the compiled schema instance.

--- a/docs/Validator.md
+++ b/docs/Validator.md
@@ -32,7 +32,7 @@ The BlazeWrapper Validator enables fast and robust validation of JSON data again
 
 **Validates a JSON instance against a schema. Returns a simple boolean result.**
 ```java
-public static boolean validate(CompiledSchema schema, String instance)
+public boolean validate(CompiledSchema schema, String instance)
 ```
 - **Parameters:**
   - `schema`: The compiled schema.
@@ -42,11 +42,11 @@ public static boolean validate(CompiledSchema schema, String instance)
 
 ---
 
-### `validateWithDetails(CompiledSchema schema, String instance`
+### `validateWithDetails(CompiledSchema schema, String instance)`
 
 **Validates a JSON instance against a schema and returns detailed validation results.**
 ```java
-public static ValidationResult validateWithDetails(CompiledSchema schema, String instance)
+public ValidationResult validateWithDetails(CompiledSchema schema, String instance)
 ```
 
 - **Parameters:**
@@ -61,45 +61,46 @@ public static ValidationResult validateWithDetails(CompiledSchema schema, String
 
 ### Basic Boolean Validation
 ```java
-String schemaJson = "{"
-+ ""$schema": "https://json-schema.org/draft/2020-12/schema\","
-+ ""type": "string""
-+ "}";
+String schemaJson = """
+    {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string"
+    }
+    """;
 
-try (CompiledSchema schema = Blaze.compile(schemaJson)) {
+SchemaCompiler compiler = new SchemaCompiler();
+try (CompiledSchema schema = compiler.compile(schemaJson)) {
+    BlazeValidator validator = new BlazeValidator();
+    boolean validStringResult = validator.validate(schema, "\"hello\"");
 
-boolean validStringResult = Blaze.validate(schema, ""hello"");
-
-System.out.println("Validation result for "hello": " + validStringResult);
-assertTrue(validStringResult);
+    System.out.println("Validation result for \"hello\": " + validStringResult);
 }
-
 ```
 
 ---
 
 ### Detailed Validation with Error Reporting
 ```java
-String schemaJson = "{"
-+ "\"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
-+ "\"enum\": [\"red\", \"green\", \"blue\"]"
-+ "}";
+String schemaJson = """
+    {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "enum": ["red", "green", "blue"]
+    }
+    """;
 
 String instance = "\"yellow\"";
 
-try (CompiledSchema compiledSchema = Blaze.compile(schemaJson)) {
-    ValidationResult result = Blaze.validateWithDetails(compiledSchema, instance);
+SchemaCompiler compiler = new SchemaCompiler();
+try (CompiledSchema compiledSchema = compiler.compile(schemaJson)) {
+    BlazeValidator validator = new BlazeValidator();
+    ValidationResult result = validator.validateWithDetails(compiledSchema, instance);
 
     System.out.println(result.isValid());
 
     if (!result.isValid()) {
         result.getErrors().forEach(System.out::println);
     }
-
-    assertFalse(result.isValid());
 }
-
-
 ```
 
 **Sample error output:**


### PR DESCRIPTION

This PR updates the Blaze4j documentation to use  Java multiline strings (text blocks) and corrects the API usage to match the actual implementation. The documentation now shows the proper usage of `SchemaCompiler` and `BlazeValidator` classes instead of static methods.

